### PR TITLE
Creation of requirements.txt for the dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 * chardet
 
 ```
-sudo pip3 install python-crfsuite
-sudo pip3 install Flask
-sudo pip3 install chardet
+pip install -r requirements.txt
 ```
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-crfsuite
+Flask
+chardet


### PR DESCRIPTION
I am using **luima_sbd** in my project, and it seemed more convenient to install the dependencies from requirements.txt, since you may have several submodules in your repositories and want to install them with a single command.

Example structure of a project using **luima_sbd** as a submodule:

- requirements.txt
- Submodule 1
     - requirements.txt
     - Submodule 1.1
          - requirements.txt
- Submodule 2
     - requirements.txt
- luima_sbd
     - requirements.txt

**Use Case:** You would want to set up the environment with a single command, which then installs the root dependencies along with the submodule dependencies.